### PR TITLE
Catch overflow errors and output a warning

### DIFF
--- a/spec/grpc_spec.cr
+++ b/spec/grpc_spec.cr
@@ -3,7 +3,4 @@ require "./spec_helper"
 describe GRPC do
   # TODO: Write tests
 
-  it "works" do
-    false.should eq(true)
-  end
 end

--- a/src/http2.cr
+++ b/src/http2.cr
@@ -376,6 +376,11 @@ module HTTP2
           @state = State::Closed
           next
         end
+      rescue ex : OverflowError
+        puts "[WARN] Incoming frame size exceeds local window size of (#{@initial_window_size.get}). Conection closed."
+        # window size received is too large, closing connection
+        @socket.close
+        @state = State::Closed
       rescue ex : IO::EOFError
         # The client has closed the connection, so we don't actually need to do
         # anything here and we can exit normally.


### PR DESCRIPTION
Addresses #15 . This prevents the server from crashing cause of the frame size.

Not sure if it should do a log call instead of a puts.